### PR TITLE
Add toggle functionality for pages navigation

### DIFF
--- a/src/app/(protected)/notebooks/[notebook_id]/[page_id]/page.tsx
+++ b/src/app/(protected)/notebooks/[notebook_id]/[page_id]/page.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { PagesNavigation } from "@/components/notebooks/pages-navigation";
-import { Loader } from "@/components/loader";
 import { useQuery, gql } from "@apollo/client";
+import { Loader } from "@/components/loader";
+import { useState } from "react";
+
 import PageEditor from "@/components/pages/editor";
 
 const NOTEBOOK_QUERY = gql`
@@ -25,6 +27,7 @@ export default function Page({
 }: {
   params: { notebook_id: string; page_id: string };
 }) {
+  const [isNavVisible, setIsNavVisible] = useState(true);
   const { data, loading, error, refetch } = useQuery(NOTEBOOK_QUERY, {
     variables: {
       id: params.notebook_id,
@@ -39,15 +42,20 @@ export default function Page({
 
   return (
     <div className="flex h-screen items-stretch">
-      <PagesNavigation
-        notebook={data?.notebook}
-        currentPageId={params.page_id}
-        onUpdate={() => refetch() }
+      {isNavVisible && (
+        <PagesNavigation
+          notebook={data?.notebook}
+          currentPageId={params.page_id}
+          onUpdate={() => refetch()}
+        />
+      )}
+      <div
+        className={`resizable-divider ${isNavVisible ? '' : 'closed'}`}
+        onClick={() => setIsNavVisible(!isNavVisible)}
       />
-      <div className="flex-[4]" >
+      <div className="flex-[4]">
         <PageEditor page_id={params.page_id} />
       </div>
-
     </div>
   );
 }

--- a/src/app/(protected)/notebooks/[notebook_id]/page.tsx
+++ b/src/app/(protected)/notebooks/[notebook_id]/page.tsx
@@ -2,7 +2,6 @@
 
 import { PagesNavigation } from "@/components/notebooks/pages-navigation";
 import { Loader } from "@/components/loader";
-import { useEffect} from 'react';
 import { useQuery, gql } from "@apollo/client";
 import { useRouter } from 'next/navigation';
 

--- a/src/components/auth-provider.tsx
+++ b/src/components/auth-provider.tsx
@@ -1,5 +1,5 @@
-import { createContext, useContext, useState, useEffect } from "react";
-import { useQuery, gql, useSuspenseQuery } from '@apollo/client';
+import { createContext, useContext, useState } from "react";
+import { useQuery, gql } from '@apollo/client';
 import { useRouter } from 'next/navigation';
 import { Notify } from '@config/notiflix-config';
 import { Loader } from '@components/loader';

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { usePathname } from 'next/navigation';
-import { useEffect, useState } from 'react';
 import { useAuth } from '@components/auth-provider';
 
 export default function Navigation() {

--- a/src/components/notebooks/pages-navigation.css
+++ b/src/components/notebooks/pages-navigation.css
@@ -39,3 +39,18 @@
 .bottom-page-actions {
   @apply grid grid-cols-1 gap-1 pt-3;
 }
+
+.resizable-divider{
+  width: 10px;
+  cursor: w-resize;
+  background-color: transparent;
+  position: relative;
+}
+
+.resizable-divider:hover {
+  background-color: rgba(0, 0, 0, 0.1);
+}
+
+.resizable-divider.closed {
+  cursor: e-resize;
+}

--- a/src/components/notebooks/pages-navigation.tsx
+++ b/src/components/notebooks/pages-navigation.tsx
@@ -8,7 +8,7 @@ import { useMutation, gql } from "@apollo/client";
 import NotebookForm from "@/components/notebooks/form";
 import DeletePageForm from '@/components/pages/delete';
 import {
-  TrashIcon, PlusIcon, ChevronLeftIcon, Cog8ToothIcon
+  TrashIcon, ChevronLeftIcon, Cog8ToothIcon
 } from "@heroicons/react/24/solid";
 import { Modal, openModal, closeModal } from "@/components/modal";
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,4 @@
 import { NextResponse, NextRequest } from 'next/server';
-import { user } from '@components/auth-provider';
 
 export function middleware(request: NextRequest) {
   if (request.cookies.has('token')) {


### PR DESCRIPTION
Feature: New toggle functionality for page navigation. A clickable resizable divider between the page navigation and text editor to close or open the page's navigation.

Cleanup: Removed unused import found in the codebase.